### PR TITLE
Code clean up and add support for passing the request through the whole token generation lifecycle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ The interface _CredentialsVerifier_ defines the hooks called during the token ge
 The methods are called in this order:
 - _ValidateUser() or ValidateClient()_ called first for credentials verification
 - _AddClaims()_ used for add information to the token that will be encrypted
-- _StoreTokenID()_ called after the token generation but before the response, programmers can use this method for storing the generated Ids
+- _StoreTokenID()_ called after the token generation but before the response, programmers can use this method for storing the generated IDs
 - _AddProperties()_ used for add clear information to the response
 
 There is another method in the _CredentialsVerifier_ interface that is involved during the refresh token process. 
 In this case the methods are called in this order:
-- _ValidateTokenID()_ called first for TokenId verification, the method receives the TokenId related to the token associated to the refresh token
+- _ValidateTokenID()_ called first for TokenID verification, the method receives the TokenID related to the token associated to the refresh token
 - _AddClaims()_ used for add information to the token that will be encrypted
-- _StoreTokenID()_ called after the token regeneration but before the response, programmers can use this method for storing the generated Ids
+- _StoreTokenID()_ called after the token regeneration but before the response, programmers can use this method for storing the generated IDs
 - _AddProperties()_ used for add clear information to the response
 
 ## Authorization Server usage example

--- a/example/authserver/main.go
+++ b/example/authserver/main.go
@@ -100,15 +100,15 @@ func (*TestUserVerifier) ValidateCode(clientID, clientSecret, code, redirectURI 
 // AddClaims provides additional claims to the token
 func (*TestUserVerifier) AddClaims(tokenType oauth.TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	claims := make(map[string]string)
-	claims["customerID"] = "1001"
-	claims["customerData"] = `{"order_date":"2016-12-14","order_id":"9999"}`
+	claims["customer_id"] = "1001"
+	claims["customer_data"] = `{"order_date":"2016-12-14","order_id":"9999"}`
 	return claims, nil
 }
 
 // AddProperties provides additional information to the token response
 func (*TestUserVerifier) AddProperties(tokenType oauth.TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	props := make(map[string]string)
-	props["customerName"] = "Gopher"
+	props["customer_name"] = "Gopher"
 	return props, nil
 }
 

--- a/example/authserver/main.go
+++ b/example/authserver/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
+
 	"github.com/go-chi/oauth"
 )
 
@@ -63,7 +63,7 @@ func main() {
 }
 
 func registerAPI(r *chi.Mux) {
-	s := oauth.NewOAuthBearerServer(
+	s := oauth.NewBearerServer(
 		"mySecretKey-10101",
 		time.Second*120,
 		&TestUserVerifier{},
@@ -77,36 +77,38 @@ type TestUserVerifier struct {
 }
 
 // ValidateUser validates username and password returning an error if the user credentials are wrong
-func (*TestUserVerifier) ValidateUser(username, password, scope string, req *http.Request) error {
+func (*TestUserVerifier) ValidateUser(username, password, scope string, r *http.Request) error {
 	if username == "user01" && password == "12345" {
 		return nil
 	}
-	return errors.New("Wrong user")
+
+	return errors.New("wrong user")
 }
 
 // ValidateClient validates clientId and secret returning an error if the client credentials are wrong
-func (*TestUserVerifier) ValidateClient(clientID, clientSecret, scope string, req *http.Request) error {
+func (*TestUserVerifier) ValidateClient(clientID, clientSecret, scope string, r *http.Request) error {
 	if clientID == "abcdef" && clientSecret == "12345" {
 		return nil
 	}
-	return errors.New("Wrong client")
+
+	return errors.New("wrong client")
+}
+
+// ValidateCode validates token ID
+func (*TestUserVerifier) ValidateCode(clientID, clientSecret, code, redirectURI string, r *http.Request) (string, error) {
+	return "", nil
 }
 
 // AddClaims provides additional claims to the token
-func (*TestUserVerifier) AddClaims(ctx context.Context, tokenType oauth.TokenType, credential, tokenID, scope string) (map[string]string, error) {
+func (*TestUserVerifier) AddClaims(tokenType oauth.TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	claims := make(map[string]string)
-	claims["customerId"] = "1001"
+	claims["customerID"] = "1001"
 	claims["customerData"] = `{"OrderDate":"2016-12-14","OrderId":"9999"}`
 	return claims, nil
 }
 
-// StoreTokenId saves the token id generated for the user
-func (*TestUserVerifier) StoreTokenID(tokenType oauth.TokenType, credential, tokenID, refreshTokenID string) error {
-	return nil
-}
-
 // AddProperties provides additional information to the token response
-func (*TestUserVerifier) AddProperties(ctx context.Context, tokenType oauth.TokenType, credential, tokenID, scope string) (map[string]string, error) {
+func (*TestUserVerifier) AddProperties(tokenType oauth.TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	props := make(map[string]string)
 	props["customerName"] = "Gopher"
 	return props, nil
@@ -117,7 +119,8 @@ func (*TestUserVerifier) ValidateTokenID(tokenType oauth.TokenType, credential, 
 	return nil
 }
 
-// ValidateCode validates token ID
-func (*TestUserVerifier) ValidateCode(clientID, clientSecret, code, redirectURI string, req *http.Request) (string, error) {
-	return "", nil
+// StoreTokenId saves the token id generated for the user
+func (*TestUserVerifier) StoreTokenID(tokenType oauth.TokenType, credential, tokenID, refreshTokenID string) error {
+	return nil
 }
+

--- a/example/authserver/main.go
+++ b/example/authserver/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
-
 	"github.com/go-chi/oauth"
 )
 
@@ -25,7 +24,7 @@ import (
 
 		grant_type=password&username=user01&password=12345
 
-	Generate Token using clientId & secret
+	Generate Token using clientID & secret
 
     	POST http://localhost:3000/auth
 		User-Agent: Fiddler
@@ -44,7 +43,6 @@ import (
 		Content-Type: application/x-www-form-urlencoded
 
 		grant_type=refresh_token&refresh_token={the refresh_token obtained in the previous response}
-
 */
 func main() {
 	r := chi.NewRouter()
@@ -85,7 +83,7 @@ func (*TestUserVerifier) ValidateUser(username, password, scope string, r *http.
 	return errors.New("wrong user")
 }
 
-// ValidateClient validates clientId and secret returning an error if the client credentials are wrong
+// ValidateClient validates clientID and secret returning an error if the client credentials are wrong
 func (*TestUserVerifier) ValidateClient(clientID, clientSecret, scope string, r *http.Request) error {
 	if clientID == "abcdef" && clientSecret == "12345" {
 		return nil
@@ -103,7 +101,7 @@ func (*TestUserVerifier) ValidateCode(clientID, clientSecret, code, redirectURI 
 func (*TestUserVerifier) AddClaims(tokenType oauth.TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	claims := make(map[string]string)
 	claims["customerID"] = "1001"
-	claims["customerData"] = `{"OrderDate":"2016-12-14","OrderId":"9999"}`
+	claims["customerData"] = `{"order_date":"2016-12-14","order_id":"9999"}`
 	return claims, nil
 }
 
@@ -114,12 +112,12 @@ func (*TestUserVerifier) AddProperties(tokenType oauth.TokenType, credential, to
 	return props, nil
 }
 
-// ValidateTokenId validates token ID
+// ValidateTokenID validates token ID
 func (*TestUserVerifier) ValidateTokenID(tokenType oauth.TokenType, credential, tokenID, refreshTokenID string) error {
 	return nil
 }
 
-// StoreTokenId saves the token id generated for the user
+// StoreTokenID saves the token id generated for the user
 func (*TestUserVerifier) StoreTokenID(tokenType oauth.TokenType, credential, tokenID, refreshTokenID string) error {
 	return nil
 }

--- a/example/resourceserver/main.go
+++ b/example/resourceserver/main.go
@@ -86,9 +86,9 @@ func GetCustomers(w http.ResponseWriter, _ *http.Request) {
 
 func GetOrders(w http.ResponseWriter, _ *http.Request) {
 	renderJSON(w, `{
-		"status":          "sent",
-		"customer":        "test001",
-		"OrderId":         "100234",
-		"TotalOrderItems": "199",
+		"status":            "sent",
+		"customer":          "test001",
+		"order_id":          "100234",
+		"total_order_items": "199",
 	}`, http.StatusOK)
 }

--- a/example/resourceserver/main.go
+++ b/example/resourceserver/main.go
@@ -87,7 +87,7 @@ func GetCustomers(w http.ResponseWriter, _ *http.Request) {
 func GetOrders(w http.ResponseWriter, _ *http.Request) {
 	renderJSON(w, `{
 		"status":          "sent",
-		"customer":        c.Param("id"),
+		"customer":        "test001",
 		"OrderId":         "100234",
 		"TotalOrderItems": "199",
 	}`, http.StatusOK)

--- a/example/resourceserver/main.go
+++ b/example/resourceserver/main.go
@@ -79,8 +79,8 @@ func GetCustomers(w http.ResponseWriter, _ *http.Request) {
 	renderJSON(w, `{
 		"Status":        "verified",
 		"Customer":      "test001",
-		"CustomerName":  "Max",
-		"CustomerEmail": "test@test.com",
+		"Customer_name":  "Max",
+		"Customer_email": "test@test.com",
 	}`, http.StatusOK)
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -13,7 +14,8 @@ func init() {
 }
 
 func TestAuthorizationHeader(t *testing.T) {
-	resp, code := _sut.generateTokenResponse("password", "user111", "password111", "", "", "", "", nil)
+	r := new(http.Request)
+	resp, code := _sut.generateTokenResponse("password", "user111", "password111", "", "", "", "", r)
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -38,15 +38,15 @@ func (TestUserVerifier) ValidateUser(username, password, scope string, r *http.R
 	}
 }
 
-// Validate clientId and secret returning an error if the client credentials are wrong
-func (TestUserVerifier) ValidateClient(clientId, clientSecret, scope string, r *http.Request) error {
+// Validate clientID and secret returning an error if the client credentials are wrong
+func (TestUserVerifier) ValidateClient(clientID, clientSecret, scope string, r *http.Request) error {
 	// Add something to the request context, so we can access it in the claims and props funcs.
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, "oauth.claims.test", "test")
 	ctx = context.WithValue(ctx, "oauth.props.test", "test")
 	*r = *r.Clone(ctx)
 
-	if clientId == "abcdef" && clientSecret == "12345" {
+	if clientID == "abcdef" && clientSecret == "12345" {
 		return nil
 	}
 	return errors.New("wrong client")
@@ -56,12 +56,12 @@ func (TestUserVerifier) ValidateClient(clientId, clientSecret, scope string, r *
 func (TestUserVerifier) AddClaims(tokenType TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	claims := make(map[string]string)
 	claims["customerID"] = "1001"
-	claims["customerData"] = `{"OrderDate":"2016-12-14","OrderId":"9999"}`
+	claims["customerData"] = `{"order_date":"2016-12-14","order_id":"9999"}`
 
 	// Get value from request context, and add it to our claims.
 	test := r.Context().Value("oauth.claims.test")
 	if test != nil {
-		claims["ctxValue"] = test.(string)
+		claims["ctx_value"] = test.(string)
 	}
 	return claims, nil
 }
@@ -74,7 +74,7 @@ func (TestUserVerifier) AddProperties(tokenType TokenType, credential, tokenID, 
 	// Get value from request context, and add it to our props.
 	test := r.Context().Value("oauth.props.test")
 	if test != nil {
-		props["ctxValue"] = test.(string)
+		props["ctx_value"] = test.(string)
 	}
 	return props, nil
 }
@@ -149,8 +149,8 @@ func TestGenerateToken4Password(t *testing.T) {
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
 	}
-	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
-		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
+	if resp.(*TokenResponse).Properties["ctx_value"] != "test" {
+		t.Fatalf("Error ctx_value invalid = %s", resp.(*TokenResponse).Properties["ctx_value"])
 	}
 	t.Logf("Token response: %v", resp)
 }
@@ -168,8 +168,8 @@ func TestGenerateToken4ClientCredentials(t *testing.T) {
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
 	}
-	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
-		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
+	if resp.(*TokenResponse).Properties["ctx_value"] != "test" {
+		t.Fatalf("Error ctx_value invalid = %s", resp.(*TokenResponse).Properties["ctx_value"])
 	}
 	t.Logf("Token response: %v", resp)
 }
@@ -180,8 +180,8 @@ func TestRefreshToken4ClientCredentials(t *testing.T) {
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
 	}
-	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
-		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
+	if resp.(*TokenResponse).Properties["ctx_value"] != "test" {
+		t.Fatalf("Error ctx_value invalid = %s", resp.(*TokenResponse).Properties["ctx_value"])
 	}
 	t.Logf("Token Response: %v", resp)
 	resp2, code2 := _sut.generateTokenResponse(RefreshTokenGrant, "", "", resp.(*TokenResponse).RefreshToken, "", "", "", r)

--- a/server_test.go
+++ b/server_test.go
@@ -55,8 +55,8 @@ func (TestUserVerifier) ValidateClient(clientID, clientSecret, scope string, r *
 // Provide additional claims to the token
 func (TestUserVerifier) AddClaims(tokenType TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	claims := make(map[string]string)
-	claims["customerID"] = "1001"
-	claims["customerData"] = `{"order_date":"2016-12-14","order_id":"9999"}`
+	claims["customer_id"] = "1001"
+	claims["customer_data"] = `{"order_date":"2016-12-14","order_id":"9999"}`
 
 	// Get value from request context, and add it to our claims.
 	test := r.Context().Value("oauth.claims.test")
@@ -69,7 +69,7 @@ func (TestUserVerifier) AddClaims(tokenType TokenType, credential, tokenID, scop
 // Provide additional information to the token response
 func (TestUserVerifier) AddProperties(tokenType TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
 	props := make(map[string]string)
-	props["customerName"] = "Gopher"
+	props["customer_name"] = "Gopher"
 
 	// Get value from request context, and add it to our props.
 	test := r.Context().Value("oauth.props.test")

--- a/server_test.go
+++ b/server_test.go
@@ -8,18 +8,90 @@ import (
 	"time"
 )
 
-var _sut *OAuthBearerServer
+var _sut = NewBearerServer(
+	"mySecretKey-10101",
+	time.Second*60,
+	new(TestUserVerifier),
+	nil)
 
-func init() {
-	_sut = NewOAuthBearerServer(
-		"mySecretKey-10101",
-		time.Second*60,
-		&TestUserVerifier{},
-		nil)
+// TestUserVerifier provides user credentials verifier for testing.
+type TestUserVerifier struct {
+}
+
+// Validate username and password returning an error if the user credentials are wrong
+func (TestUserVerifier) ValidateUser(username, password, scope string, r *http.Request) error {
+	// Add something to the request context, so we can access it in the claims and props funcs.
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, "oauth.claims.test", "test")
+	ctx = context.WithValue(ctx, "oauth.props.test", "test")
+	*r = *r.Clone(ctx)
+
+	switch {
+	case username == "user111" && password == "password111":
+		return nil
+	case username == "user222" && password == "password222":
+		return nil
+	case username == "user333" && password == "password333":
+		return nil
+	default:
+		return errors.New("wrong user")
+	}
+}
+
+// Validate clientId and secret returning an error if the client credentials are wrong
+func (TestUserVerifier) ValidateClient(clientId, clientSecret, scope string, r *http.Request) error {
+	// Add something to the request context, so we can access it in the claims and props funcs.
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, "oauth.claims.test", "test")
+	ctx = context.WithValue(ctx, "oauth.props.test", "test")
+	*r = *r.Clone(ctx)
+
+	if clientId == "abcdef" && clientSecret == "12345" {
+		return nil
+	}
+	return errors.New("wrong client")
+}
+
+// Provide additional claims to the token
+func (TestUserVerifier) AddClaims(tokenType TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
+	claims := make(map[string]string)
+	claims["customerID"] = "1001"
+	claims["customerData"] = `{"OrderDate":"2016-12-14","OrderId":"9999"}`
+
+	// Get value from request context, and add it to our claims.
+	test := r.Context().Value("oauth.claims.test")
+	if test != nil {
+		claims["ctxValue"] = test.(string)
+	}
+	return claims, nil
+}
+
+// Provide additional information to the token response
+func (TestUserVerifier) AddProperties(tokenType TokenType, credential, tokenID, scope string, r *http.Request) (map[string]string, error) {
+	props := make(map[string]string)
+	props["customerName"] = "Gopher"
+
+	// Get value from request context, and add it to our props.
+	test := r.Context().Value("oauth.props.test")
+	if test != nil {
+		props["ctxValue"] = test.(string)
+	}
+	return props, nil
+}
+
+// Validate token ID
+func (TestUserVerifier) ValidateTokenID(tokenType TokenType, credential, tokenID, refreshTokenID string) error {
+	return nil
+}
+
+// Optionally store the token ID generated for the user
+func (TestUserVerifier) StoreTokenID(tokenType TokenType, credential, tokenID, refreshTokenID string) error {
+	return nil
 }
 
 func TestGenerateTokensByUsername(t *testing.T) {
-	token, refresh, err := _sut.generateTokens("user111", "U", "")
+	r := new(http.Request)
+	token, refresh, err := _sut.generateTokens(UserToken, "user111", "", r)
 	if err == nil {
 		t.Logf("Token: %v", token)
 		t.Logf("Refresh Token: %v", refresh)
@@ -29,14 +101,16 @@ func TestGenerateTokensByUsername(t *testing.T) {
 }
 
 func TestCryptTokens(t *testing.T) {
-	token, refresh, err := _sut.generateTokens("user222", "U", "")
+	r := new(http.Request)
+	token, refresh, err := _sut.generateTokens(UserToken, "user222","", r)
 	if err == nil {
 		t.Logf("Token: %v", token)
 		t.Logf("Refresh Token: %v", refresh)
 	} else {
 		t.Fatalf("Error %s", err.Error())
 	}
-	resp, err := _sut.cryptTokens(token, refresh)
+
+	resp, err := _sut.cryptTokens(token, refresh, r)
 	if err == nil {
 		t.Logf("Response: %v", resp)
 	} else {
@@ -45,20 +119,23 @@ func TestCryptTokens(t *testing.T) {
 }
 
 func TestDecryptRefreshTokens(t *testing.T) {
-	token, refresh, err := _sut.generateTokens("user333", "U", "")
+	r := new(http.Request)
+	token, refresh, err := _sut.generateTokens(UserToken,"user333","", r)
 	if err == nil {
 		t.Logf("Token: %v", token)
 		t.Logf("Refresh Token: %v", refresh)
 	} else {
 		t.Fatalf("Error %s", err.Error())
 	}
-	resp, err := _sut.cryptTokens(token, refresh)
+
+	resp, err := _sut.cryptTokens(token, refresh, r)
 	if err == nil {
 		t.Logf("Response: %v", resp)
 		t.Logf("Response Refresh Token: %v", resp.RefreshToken)
 	} else {
 		t.Fatalf("Error %s", err.Error())
 	}
+
 	refresh2, err := _sut.provider.DecryptRefreshTokens(resp.RefreshToken)
 	if err == nil {
 		t.Logf("Refresh Token Decrypted: %v", refresh2)
@@ -68,15 +145,18 @@ func TestDecryptRefreshTokens(t *testing.T) {
 }
 
 func TestGenerateToken4Password(t *testing.T) {
-	resp, code := _sut.generateTokenResponse("password", "user111", "password111", "", "", "", "", nil)
+	resp, code := _sut.generateTokenResponse(PasswordGrant, "user111", "password111", "", "", "", "", new(http.Request))
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
+	}
+	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
+		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
 	}
 	t.Logf("Token response: %v", resp)
 }
 
 func TestShouldFailGenerateToken4Password(t *testing.T) {
-	_, code := _sut.generateTokenResponse("password", "user111", "password4444", "", "", "", "", nil)
+	_, code := _sut.generateTokenResponse(PasswordGrant, "user111", "password4444", "", "", "", "", new(http.Request))
 	t.Logf("Server response: %v", code)
 	if code != 401 {
 		t.Fatalf("Error StatusCode = %d", code)
@@ -84,73 +164,29 @@ func TestShouldFailGenerateToken4Password(t *testing.T) {
 }
 
 func TestGenerateToken4ClientCredentials(t *testing.T) {
-	resp, code := _sut.generateTokenResponse("client_credentials", "abcdef", "12345", "", "", "", "", nil)
+	resp, code := _sut.generateTokenResponse(ClientCredentialsGrant, "abcdef", "12345", "", "", "", "", new(http.Request))
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
+	}
+	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
+		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
 	}
 	t.Logf("Token response: %v", resp)
 }
 
 func TestRefreshToken4ClientCredentials(t *testing.T) {
-	resp, code := _sut.generateTokenResponse("client_credentials", "abcdef", "12345", "", "", "", "", nil)
+	r := new(http.Request)
+	resp, code := _sut.generateTokenResponse(ClientCredentialsGrant, "abcdef", "12345", "", "", "", "", r)
 	if code != 200 {
 		t.Fatalf("Error StatusCode = %d", code)
 	}
+	if resp.(*TokenResponse).Properties["ctxValue"] != "test" {
+		t.Fatalf("Error ctxValue invalid = %s", resp.(*TokenResponse).Properties["ctxValue"])
+	}
 	t.Logf("Token Response: %v", resp)
-	resp2, code2 := _sut.generateTokenResponse("refresh_token", "", "", resp.(*TokenResponse).RefreshToken, "", "", "", nil)
+	resp2, code2 := _sut.generateTokenResponse(RefreshTokenGrant, "", "", resp.(*TokenResponse).RefreshToken, "", "", "", r)
 	if code2 != 200 {
 		t.Fatalf("Error StatusCode = %d", code2)
 	}
 	t.Logf("New Token Response: %v", resp2)
-}
-
-// TestUserVerifier provides user credentials verifier for testing.
-type TestUserVerifier struct {
-}
-
-// Validate username and password returning an error if the user credentials are wrong
-func (*TestUserVerifier) ValidateUser(username, password, scope string, req *http.Request) error {
-	if username == "user111" && password == "password111" {
-		return nil
-	} else if username == "user222" && password == "password222" {
-		return nil
-	} else if username == "user333" && password == "password333" {
-		return nil
-	} else {
-		return errors.New("Wrong user")
-	}
-}
-
-// Validate clientId and secret returning an error if the client credentials are wrong
-func (*TestUserVerifier) ValidateClient(clientId, clientSecret, scope string, req *http.Request) error {
-	if clientId == "abcdef" && clientSecret == "12345" {
-		return nil
-	} else {
-		return errors.New("Wrong client")
-	}
-}
-
-// Provide additional claims to the token
-func (*TestUserVerifier) AddClaims(ctx context.Context, tokenType TokenType, credential, tokenID, scope string) (map[string]string, error) {
-	claims := make(map[string]string)
-	claims["customerId"] = "1001"
-	claims["customerData"] = `{"OrderDate":"2016-12-14","OrderId":"9999"}`
-	return claims, nil
-}
-
-// Optionally store the token ID generated for the user
-func (*TestUserVerifier) StoreTokenID(tokenType TokenType, credential, tokenID, refreshTokenID string) error {
-	return nil
-}
-
-// Provide additional information to the token response
-func (*TestUserVerifier) AddProperties(ctx context.Context, tokenType TokenType, credential, tokenID, scope string) (map[string]string, error) {
-	props := make(map[string]string)
-	props["customerName"] = "Gopher"
-	return props, nil
-}
-
-// Validate token ID
-func (*TestUserVerifier) ValidateTokenID(tokenType TokenType, credential, tokenID, refreshTokenID string) error {
-	return nil
 }


### PR DESCRIPTION
@pkieltyka sorry for the post merge PR, but I realized I needed to add support for passing the request object through all of the validation and claims/props funcs to allow someone to add something to the request context in the validation step which could then be added as a claim or property if needed. I needed this functionality so I could add some claims dynamically based on the user/secret used when requesting an oauth token.

I also went through the code again and cleaned it up more... 